### PR TITLE
fix: Stop empty collections or media lists from throwing frontend erros

### DIFF
--- a/web/src/routes/(admin)/+layout.server.ts
+++ b/web/src/routes/(admin)/+layout.server.ts
@@ -14,6 +14,11 @@ export const load: LayoutServerLoad = async ({ cookies, fetch, locals }) => {
 
 	const response = await fetch(`${env.PUBLIC_API_URL}/v1/collections`);
 
+	if (!response.ok) {
+		console.error('Failed to fetch collections:', response.status, await response.text());
+		return { collections: [] };
+	}
+
 	const collections = (await response.json()) as Collection[];
 
 	return {

--- a/web/src/routes/(admin)/media/+page.server.ts
+++ b/web/src/routes/(admin)/media/+page.server.ts
@@ -7,6 +7,11 @@ export const load: PageServerLoad = async ({ fetch }) => {
 		}
 	});
 
+	if (!response.ok) {
+		console.error('Failed to fetch media:', response.status, await response.text());
+		return { media: [] };
+	}
+
 	const data = await response.json();
 
 	return { media: data };


### PR DESCRIPTION
Closes #151 