### PR TITLE
Publish sdk and cli to npm in github action.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,8 @@ jobs:
       landing: ${{ steps.changes.outputs.landing }}
       api: ${{ steps.changes.outputs.api }}
       web: ${{ steps.changes.outputs.web }}
+      cli: ${{ steps.changes.outputs.cli }}
+      sdk: ${{ steps.changes.outputs.sdk }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,6 +35,10 @@ jobs:
               - 'api/**'
             web:
               - 'web/**'
+            cli:
+              - 'cli/**'
+            sdk:
+              - 'sdk/**'
 
   test-landing:
     runs-on: ubuntu-latest
@@ -63,6 +69,66 @@ jobs:
 
       - name: Setup playwright
         run: pnpm exec playwright install
+
+      - name: Run unit tests
+        run: pnpm test:unit
+
+  test-sdk:
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.sdk == 'true'
+    defaults:
+      run:
+        working-directory: sdk
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+          cache-dependency-path: sdk/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run unit tests
+        run: pnpm test:unit
+
+  test-cli:
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.cli == 'true'
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+          cache-dependency-path: cli/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install
 
       - name: Run unit tests
         run: pnpm test:unit
@@ -240,6 +306,8 @@ jobs:
       [
         changes,
         test-landing,
+        test-sdk,
+        test-cli,
         test-api,
         test-web,
         build-landing,
@@ -251,6 +319,14 @@ jobs:
       - name: Report status
         run: |
           if [ "${{ needs.changes.outputs.landing }}" == 'true' ] && [ "${{ needs.test-landing.result }}" != 'success' ] && [ "${{ needs.build-landing.result }}" != 'success' ]; then
+            exit 1;
+          fi
+
+          if [ "${{ needs.changes.outputs.sdk }}" == 'true' ] && [ "${{ needs.test-sdk.result }}" != 'success' ]; then
+            exit 1;
+          fi
+
+          if [ "${{ needs.changes.outputs.cli }}" == 'true' ] && [ "${{ needs.test-cli.result }}" != 'success' ]; then
             exit 1;
           fi
 

--- a/.github/workflows/publish-cli.yaml
+++ b/.github/workflows/publish-cli.yaml
@@ -1,4 +1,4 @@
-name: Publish to NPM
+name: Publish cli to NPM
 
 on:
   workflow_dispatch:
@@ -7,46 +7,9 @@ permissions:
   contents: read
 
 jobs:
-  publish-sdk:
-    name: Publish sdk
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: sdk
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: "pnpm"
-          cache-dependency-path: sdk/pnpm-lock.yaml
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Run tests
-        run: pnpm test:unit
-
-      - name: Build package
-        run: pnpm build
-
-      - name: Publish to NPM
-        run: pnpm publish --access public
-
   publish-cli:
     name: Publish cli
     runs-on: ubuntu-latest
-    needs: publish-sdk
     defaults:
       run:
         working-directory: cli
@@ -79,3 +42,5 @@ jobs:
 
       - name: Publish to NPM
         run: pnpm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -1,0 +1,81 @@
+name: Publish to NPM
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish-sdk:
+    name: Publish sdk
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+          cache-dependency-path: sdk/pnpm-lock.yaml
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run tests
+        run: pnpm test:unit
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Publish to NPM
+        run: pnpm publish --access public
+
+  publish-cli:
+    name: Publish cli
+    runs-on: ubuntu-latest
+    needs: publish-sdk
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+          cache-dependency-path: cli/pnpm-lock.yaml
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run tests
+        run: pnpm test:unit
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Publish to NPM
+        run: pnpm publish --access public

--- a/.github/workflows/publish-sdk.yaml
+++ b/.github/workflows/publish-sdk.yaml
@@ -1,0 +1,46 @@
+name: Publish sdk to NPM
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish-sdk:
+    name: Publish sdk
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+          cache-dependency-path: sdk/pnpm-lock.yaml
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run tests
+        run: pnpm test:unit
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Publish to NPM
+        run: pnpm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Closes #236.

The new publish-npm.yaml action fails if one of the two packages version (cli, sdk)  already exists on npm.